### PR TITLE
hostServices cannot open a file in a directory that includes spaces. …

### DIFF
--- a/fx/src/main/java/org/unigrid/janus/controller/NodesController.java
+++ b/fx/src/main/java/org/unigrid/janus/controller/NodesController.java
@@ -74,6 +74,7 @@ import org.unigrid.janus.model.signal.State;
 import org.unigrid.janus.model.signal.UnlockRequest;
 import org.unigrid.janus.view.backing.GridnodeListModel;
 import org.unigrid.janus.view.backing.GridnodeTxidList;
+import org.unigrid.janus.view.backing.OsxUtils;
 
 @ApplicationScoped
 public class NodesController implements Initializable, PropertyChangeListener {
@@ -90,6 +91,8 @@ public class NodesController implements Initializable, PropertyChangeListener {
 	private static GridnodeTxidList txList = new GridnodeTxidList();
 	private final Clipboard clipboard = Clipboard.getSystemClipboard();
 	private final ClipboardContent content = new ClipboardContent();
+
+	private OsxUtils osxUtils = new OsxUtils();
 
 	@FXML private TextField vpsPassword;
 	@FXML private TextField vpsAddress;
@@ -251,7 +254,11 @@ public class NodesController implements Initializable, PropertyChangeListener {
 	private void onOpenGridnodeConfigClicked(MouseEvent e) throws NullPointerException {
 		File gridnode = DataDirectory.getGridnodeFile();
 		try {
-			hostServices.showDocument(gridnode.getAbsolutePath());
+			if (SystemUtils.IS_OS_MAC_OSX) {
+				osxUtils.openFileOsx(DataDirectory.GRIDNODE_FILE);
+			} else {
+				hostServices.showDocument(gridnode.getAbsolutePath());
+			}
 		} catch (NullPointerException error) {
 			debug.print(error.getMessage(), SettingsController.class.getSimpleName());
 		}

--- a/fx/src/main/java/org/unigrid/janus/controller/SettingsController.java
+++ b/fx/src/main/java/org/unigrid/janus/controller/SettingsController.java
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.net.URL;
 import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Optional;
@@ -53,6 +54,8 @@ import javafx.scene.layout.BorderStroke;
 import javafx.scene.layout.BorderStrokeStyle;
 import javafx.scene.layout.CornerRadii;
 import javafx.stage.Stage;
+
+import org.apache.commons.lang3.SystemUtils;
 import org.unigrid.janus.model.DataDirectory;
 import org.unigrid.janus.model.JanusModel;
 import org.unigrid.janus.model.Preferences;
@@ -71,6 +74,7 @@ import org.unigrid.janus.model.signal.OverlayRequest;
 import org.unigrid.janus.model.signal.UnlockRequest;
 import org.unigrid.janus.model.signal.WalletRequest;
 import org.unigrid.janus.view.AlertDialog;
+import org.unigrid.janus.view.backing.OsxUtils;
 
 @ApplicationScoped
 public class SettingsController implements Initializable, PropertyChangeListener, Showable {
@@ -93,6 +97,8 @@ public class SettingsController implements Initializable, PropertyChangeListener
 	private static final int TAB_SETTINGS_PASSPHRASE = 3;
 	private static final int TAB_SETTINGS_EXPORT = 4;
 	private static final int TAB_SETTINGS_DEBUG = 5;
+
+	private OsxUtils osxUtils = new OsxUtils();
 
 	@FXML private ListView lstDebug;
 
@@ -211,7 +217,11 @@ public class SettingsController implements Initializable, PropertyChangeListener
 	private void onOpenConf(MouseEvent event) throws NullPointerException {
 		File conf = DataDirectory.getConfigFile();
 		try {
-			hostServices.showDocument(conf.getAbsolutePath());
+			if (SystemUtils.IS_OS_MAC_OSX) {
+				osxUtils.openFileOsx(DataDirectory.CONFIG_FILE);
+			} else {
+				hostServices.showDocument(conf.getAbsolutePath());
+			}
 		} catch (NullPointerException e) {
 			debug.print(e.getMessage(), SettingsController.class.getSimpleName());
 		}
@@ -221,19 +231,27 @@ public class SettingsController implements Initializable, PropertyChangeListener
 	private void onOpenGridnode(MouseEvent event) throws NullPointerException {
 		File gridnode = DataDirectory.getGridnodeFile();
 		try {
-			hostServices.showDocument(gridnode.getAbsolutePath());
+			if (SystemUtils.IS_OS_MAC_OSX) {
+				osxUtils.openFileOsx(DataDirectory.GRIDNODE_FILE);
+			} else {
+				hostServices.showDocument(gridnode.getAbsolutePath());
+			}
 		} catch (NullPointerException e) {
 			debug.print(e.getMessage(), SettingsController.class.getSimpleName());
 		}
 	}
 
 	@FXML
-	private void onOpenUnigrid(MouseEvent event) throws NullPointerException {
-		String gridnode = DataDirectory.get();
+	private void onOpenUnigrid(MouseEvent event) throws NullPointerException, IOException {
+		String directory = DataDirectory.get();
 		try {
-			hostServices.showDocument(gridnode);
-		} catch (NullPointerException e) {
-			System.out.println("Null Host services " + e.getMessage());
+			if (SystemUtils.IS_OS_MAC_OSX) {
+				osxUtils.openDirectory(directory);
+			} else {
+				hostServices.showDocument(directory);
+			}
+		} catch (NullPointerException | IOException e) {
+			System.out.println("open data directory " + e.getMessage());
 		}
 	}
 

--- a/fx/src/main/java/org/unigrid/janus/view/backing/OsxUtils.java
+++ b/fx/src/main/java/org/unigrid/janus/view/backing/OsxUtils.java
@@ -1,0 +1,55 @@
+/*
+	The Janus Wallet
+	Copyright © 2021-2022 The Unigrid Foundation, UGD Software AB
+
+	This program is free software: you can redistribute it and/or modify it under the terms of the
+	addended GNU Affero General Public License as published by the Free Software Foundation, version 3
+	of the License (see COPYING and COPYING.addendum).
+
+	This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received an addended copy of the GNU Affero General Public License with this program.
+	If not, see <http://www.gnu.org/licenses/> and <https://github.com/unigrid-project/janus-java>.
+ */
+
+package org.unigrid.janus.view.backing;
+
+import java.awt.Desktop;
+import java.io.File;
+import java.io.IOException;
+
+import org.unigrid.janus.model.DataDirectory;
+
+public class OsxUtils {
+
+    public void openFileOsx(String file) {
+		File path = new File(DataDirectory.get());
+		String[] cmds = new String[3];
+		cmds[0] = "open";
+		cmds[1] = "-t";
+		cmds[2] = file;
+		ProcessBuilder pb = new ProcessBuilder(cmds);
+		pb.directory(path);
+		try {
+			pb.start();
+		} catch (IOException e) {
+			System.out.println(e.getMessage());
+		}
+	}
+
+    public void openDirectory(String directory) throws IOException {
+        if(!Desktop.isDesktopSupported()) {
+            System.out.println("Cannot open data directory as desktop is not supported");
+            return;
+        }
+
+        File location = new File(directory);
+        Desktop desktop = Desktop.getDesktop();
+        if(location.exists()) {
+            desktop.open(location);
+        }
+
+    }
+}


### PR DESCRIPTION
…This happens on OSX as application support has a space. Created a helper class to open files and the directory on osx uses a process builder that passes in the directory location to exec call open.