### PR TITLE
only do the build on pull request otherwise it builds twice after the…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,6 @@
 name: Janus build status
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ The Janus Wallet © The Unigrid Foundation
 =========================================
 <img align="right" alt="Janus cryptocurrency wallet" src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Meyers_b9_s0153_b1.png" width="300"/>
 
-[![Janus build status](https://github.com/unigrid-project/janus-java/actions/workflows/maven.yml/badge.svg?branch=master)](https://github.com/unigrid-project/janus-java/actions/workflows/maven.yml)
+[![Janus build status](https://github.com/unigrid-project/janus-java/actions/workflows/maven.yml/badge.svg)](https://github.com/unigrid-project/janus-java/actions/workflows/maven.yml)
+
 
 About Unigrid
 -------------


### PR DESCRIPTION
… pull. Set the badge to just use the default so we see that pull request build status.